### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+jdk:
+- openjdk8
+cache:
+  directories:
+  - $HOME/.m2
+install: true
+script:
+-  mvn clean install -Pprod

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Work in progress.
 
+![build-status](https://travis-ci.org/HandOfGod94/xml-language-server.svg?branch=master)
+
 Language server for XML documents. It enables and LSP client (VScode, Sublime LSP, Eclipse Che) to leverage 
 capabilities such as autocomplete, validation or documentation support for XML documents.
 


### PR DESCRIPTION
Adds `travis.yml`, which uses `openjdk8` and generates artifact using `prod` maven profile
**PR for Issue:** #10 